### PR TITLE
Add adversarial actions in environment

### DIFF
--- a/gym_rarl/envs/adv_cartpole.py
+++ b/gym_rarl/envs/adv_cartpole.py
@@ -1,12 +1,10 @@
-import math
-
-from gym.envs.classic_control import CartPoleEnv
 from gym.envs.classic_control.acrobot import *
+from pybullet_envs.bullet import CartPoleBulletEnv
 
 from gym_rarl.envs.adv_env import BaseAdversarialEnv
 
 
-class AdversarialCartPoleEnv(BaseAdversarialEnv, CartPoleEnv):
+class AdversarialCartPoleEnv(BaseAdversarialEnv, CartPoleBulletEnv):
     """
     Wraps CartPole env and allows two actors to act in each step.
     """
@@ -14,60 +12,33 @@ class AdversarialCartPoleEnv(BaseAdversarialEnv, CartPoleEnv):
     def get_ob(self):
         return np.array(self.state)
 
-    def step_two_agents(self, main_action, adv_action):
+    def step_two_agents(self, action, adv_action):
         """
-        Copied from gym.envs.classic_control.cartpole.CartPoleEnv (gym==0.17.3)
+        Copied from pybullet_envs.bullet:CartPoleBulletEnv (gym==0.17.3, pybullet==3.0.7)
+        TODO: Currently we consider only discrete actions, the default (self._discrete_actions==True)
         """
-        err_msg = "%r (%s) invalid" % (main_action, type(main_action))
-        assert self.action_space.contains(main_action), err_msg
-
-        x, x_dot, theta, theta_dot = self.state
-        force = self.force_mag if main_action == 1 else -self.force_mag  # TODO apply adv_action
-        costheta = math.cos(theta)
-        sintheta = math.sin(theta)
-
-        # For the interested reader:
-        # https://coneural.org/florian/papers/05_cart_pole.pdf
-        temp = (force + self.polemass_length * theta_dot ** 2 * sintheta) / self.total_mass
-        thetaacc = (self.gravity * sintheta - costheta * temp) / (
-                self.length * (4.0 / 3.0 - self.masspole * costheta ** 2 / self.total_mass))
-        xacc = temp - self.polemass_length * thetaacc * costheta / self.total_mass
-
-        if self.kinematics_integrator == 'euler':
-            x = x + self.tau * x_dot
-            x_dot = x_dot + self.tau * xacc
-            theta = theta + self.tau * theta_dot
-            theta_dot = theta_dot + self.tau * thetaacc
-        else:  # semi-implicit euler
-            x_dot = x_dot + self.tau * xacc
-            x = x + self.tau * x_dot
-            theta_dot = theta_dot + self.tau * thetaacc
-            theta = theta + self.tau * theta_dot
-
-        self.state = (x, x_dot, theta, theta_dot)
-
-        done = bool(
-            x < -self.x_threshold
-            or x > self.x_threshold
-            or theta < -self.theta_threshold_radians
-            or theta > self.theta_threshold_radians
-        )
-
-        if not done:
-            reward = 1.0
-        elif self.steps_beyond_done is None:
-            # Pole just fell!
-            self.steps_beyond_done = 0
-            reward = 1.0
+        p = self._p
+        if self._discrete_actions:
+            force = self.force_mag if action == 1 else -self.force_mag
+            adv_force = [self.force_mag, 0, 0] if adv_action == 1 else [-self.force_mag, 0,
+                                                                        0] if adv_action == -1 else [0, 0, 0]
         else:
-            if self.steps_beyond_done == 0:
-                logger.warn(
-                    "You are calling 'step()' even though this "
-                    "environment has already returned done = True. You "
-                    "should always call 'reset()' once you receive 'done = "
-                    "True' -- any further steps are undefined behavior."
-                )
-            self.steps_beyond_done += 1
-            reward = 0.0
+            raise Exception('benjis: continuous action space not supported')
+            # force = action[0]
 
-        return self.get_ob(), reward, done, {}
+        p.applyExternalForce(self.cartpole, 1, forceObj=adv_force, posObj=[0, 0, 0], flags=p.WORLD_FRAME)
+
+        p.setJointMotorControl2(self.cartpole, 0, p.TORQUE_CONTROL, force=force)
+        p.stepSimulation()
+
+        self.state = p.getJointState(self.cartpole, 1)[0:2] + p.getJointState(self.cartpole, 0)[0:2]
+        theta, theta_dot, x, x_dot = self.state
+
+        done = x < -self.x_threshold \
+               or x > self.x_threshold \
+               or theta < -self.theta_threshold_radians \
+               or theta > self.theta_threshold_radians
+        done = bool(done)
+        reward = 1.0
+
+        return np.array(self.state), reward, done, {}

--- a/gym_rarl/envs/adv_cartpole.py
+++ b/gym_rarl/envs/adv_cartpole.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from gym.envs.classic_control.acrobot import *
 from pybullet_envs.bullet import CartPoleBulletEnv
 
@@ -20,13 +22,13 @@ class AdversarialCartPoleEnv(BaseAdversarialEnv, CartPoleBulletEnv):
         p = self._p
         if self._discrete_actions:
             force = self.force_mag if action == 1 else -self.force_mag
-            adv_force = [self.force_mag, 0, 0] if adv_action == 1 else [-self.force_mag, 0,
-                                                                        0] if adv_action == -1 else [0, 0, 0]
+            adv_force = (5, 0, 0) if adv_action == 1 else (
+                -5, 0, 0) if adv_action == -1 else (0, 0, 0)
         else:
             raise Exception('benjis: continuous action space not supported')
             # force = action[0]
 
-        p.applyExternalForce(self.cartpole, 1, forceObj=adv_force, posObj=[0, 0, 0], flags=p.WORLD_FRAME)
+        p.applyExternalForce(self.cartpole, 1, forceObj=adv_force, posObj=(0, 0, 0), flags=p.WORLD_FRAME)
 
         p.setJointMotorControl2(self.cartpole, 0, p.TORQUE_CONTROL, force=force)
         p.stepSimulation()
@@ -42,3 +44,18 @@ class AdversarialCartPoleEnv(BaseAdversarialEnv, CartPoleBulletEnv):
         reward = 1.0
 
         return np.array(self.state), reward, done, {}
+
+
+def main():
+    env = AdversarialCartPoleEnv(renders=True)
+    env.reset()
+    for _ in range(1000):
+        env.render()
+        sleep(1 / 30)
+        env.step_two_agents(0, 1)
+        # env.step(0)
+    env.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/gym_rarl/envs/rarl_env.py
+++ b/gym_rarl/envs/rarl_env.py
@@ -42,7 +42,7 @@ class MainRarlEnv(BaseRarlEnv):
         assert self.bridge.is_linked()
 
         prestep_obs = self.base.get_ob()
-        adv_action, _ = self.bridge.adv_agent.predict(prestep_obs)
+        adv_action, _ = self.bridge.adv_agent.predict(prestep_obs, deterministic=True)
         poststep_obs, r, d, i = self.base.step_two_agents(main_action, adv_action)
         return poststep_obs, r, d, i
 
@@ -56,7 +56,7 @@ class AdversarialRarlEnv(BaseRarlEnv):
         assert self.bridge.is_linked()
 
         prestep_obs = self.base.get_ob()
-        main_action, _ = self.bridge.main_agent.predict(prestep_obs)
+        main_action, _ = self.bridge.main_agent.predict(prestep_obs, deterministic=True)
         poststep_obs, r, d, i = self.base.step_two_agents(main_action, adv_action)
         return poststep_obs, -r, d, i
 

--- a/gym_rarl/envs/test_adv_cartpole.py
+++ b/gym_rarl/envs/test_adv_cartpole.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+
+from gym_rarl.envs.adv_cartpole import AdversarialCartPoleEnv
+
+
+class MyTestCase(unittest.TestCase):
+
+    def setup_method(self, _):
+        self.control_env = AdversarialCartPoleEnv()
+        self.adv_env = AdversarialCartPoleEnv()
+
+        self.control_env.seed(0)
+        self.adv_env.seed(0)
+        self.control_env.reset()
+        self.adv_env.reset()
+
+    def teardown_method(self, _):
+        self.control_env.close()
+        self.adv_env.close()
+
+    def test_reset(self):
+        self.control_env.seed(0)
+        self.adv_env.seed(0)
+        control_initial_state = self.control_env.reset()
+        adv_initial_state = self.adv_env.reset()
+
+        np.testing.assert_almost_equal(control_initial_state, adv_initial_state)
+        np.testing.assert_almost_equal(control_initial_state,
+                                       np.array([-0.04456399, 0.04653909, 0.01326909, -0.02099827]))
+
+    def test_default_step(self):
+        np.testing.assert_almost_equal(self.control_env.step(1)[0], self.adv_env.step(1)[0])
+
+    def test_adv_noop(self):
+        np.testing.assert_almost_equal(self.control_env.step(1)[0], self.adv_env.step_two_agents(1, 0)[0])
+
+    def test_adv_diff(self):
+        np.testing.assert_raises(AssertionError, np.testing.assert_almost_equal,
+                                 self.control_env.step_two_agents(1, -1)[0], self.adv_env.step_two_agents(1, 1)[0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gym_rarl/envs/test_adv_cartpole.py
+++ b/gym_rarl/envs/test_adv_cartpole.py
@@ -1,11 +1,9 @@
-import unittest
-
 import numpy as np
 
 from gym_rarl.envs.adv_cartpole import AdversarialCartPoleEnv
 
 
-class MyTestCase(unittest.TestCase):
+class TestAdversarialActionIntegration:
 
     def setup_method(self, _):
         self.control_env = AdversarialCartPoleEnv()
@@ -34,12 +32,12 @@ class MyTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(self.control_env.step(1)[0], self.adv_env.step(1)[0])
 
     def test_adv_noop(self):
-        np.testing.assert_almost_equal(self.control_env.step(1)[0], self.adv_env.step_two_agents(1, 0)[0])
+        for _ in range(10):
+            np.testing.assert_almost_equal(self.control_env.step(1)[0], self.adv_env.step_two_agents(1, 0)[0])
 
     def test_adv_diff(self):
+        for _ in range(10):
+            last_control_state = self.control_env.step_two_agents(1, -1)[0]
+            last_adv_state = self.adv_env.step_two_agents(1, 1)[0]
         np.testing.assert_raises(AssertionError, np.testing.assert_almost_equal,
-                                 self.control_env.step_two_agents(1, -1)[0], self.adv_env.step_two_agents(1, 1)[0])
-
-
-if __name__ == '__main__':
-    unittest.main()
+                                 last_control_state, last_adv_state)

--- a/main.py
+++ b/main.py
@@ -1,46 +1,65 @@
+from pybullet_envs.bullet import CartPoleBulletEnv
 from stable_baselines3 import PPO
-
 # Set up environments
+from stable_baselines3.common.env_util import make_vec_env
+from stable_baselines3.common.vec_env import VecNormalize
+
 from bridge import Bridge
 from gym_rarl.envs.adv_cartpole import AdversarialCartPoleEnv
 from gym_rarl.envs.rarl_env import MainRarlEnv, AdversarialRarlEnv
 
-# Set up environments
-base_env = AdversarialCartPoleEnv()
-bridge = Bridge()
-main_env = MainRarlEnv(base_env, bridge)
-adv_env = AdversarialRarlEnv(base_env, bridge)
 
-# Set up agents
-main_agent = PPO("MlpPolicy", main_env, verbose=1)
-adv_agent = PPO("MlpPolicy", adv_env, verbose=1)
+def dummy(env_type, seed):
+    env = make_vec_env(env_type, seed=seed)
+    # Automatically normalize the input features and reward
+    env = VecNormalize(env, norm_obs=True, norm_reward=True,
+                       clip_obs=10.)
+    return env
 
-# Link agents
-base_env.link_agents(main_agent, adv_agent)
 
-# Main agent tries to act
-obs = main_env.reset()
-a, _ = main_agent.predict(obs)
-main_env.step(a)
+def adversarial_setup():
+    base_env = AdversarialCartPoleEnv(renders=True)
+    base_env.seed(100)
 
-# Adversarial agent tries to act
-obs = adv_env.reset()
-a, _ = adv_agent.predict(obs)
-adv_env.step(a)
+    bridge = Bridge()
+    main_env = dummy(lambda: MainRarlEnv(base_env, bridge), seed=100)
+    adv_env = dummy(lambda: AdversarialRarlEnv(base_env, bridge), seed=100)
+    main_env.seed(100)
+    adv_env.seed(100)
 
-env = main_env
-model = main_agent
+    # Set up agents
+    main_agent = PPO("MlpPolicy", main_env, verbose=True, seed=123456)
+    adv_agent = PPO("MlpPolicy", adv_env, verbose=True, seed=123456)
+
+    # Link agents
+    bridge.link_agents(main_agent, adv_agent)
+
+    env = main_env
+    model = main_agent
+    return model, env
+
+
+def control_setup():
+    env = dummy(lambda: CartPoleBulletEnv(renders=True), seed=0)
+    env.seed(0)
+    model = PPO("MlpPolicy", env, verbose=True, seed=123456)
+    return model, env
+
+
+model, env = adversarial_setup()
+# model, env = control_setup()
 
 # %% Train the agent
-model.learn(total_timesteps=10000)
-model.save("models/ppo-acrobot-bleh")
+model.learn(total_timesteps=200000)
+model.save("models/ppo-cartpolebullet-200k")
+del model
 
 # %%
-model.load("models/ppo-acrobot-bleh")
+model = PPO.load("models/ppo-cartpolebullet-200k")
 obs = env.reset()
-for ts in range(5000):
+for ts in range(10000):
     env.render()
-    action, _ = model.predict(obs, deterministic=False)
+    action, _ = model.predict(obs, deterministic=True)
     obs, reward, done, info = env.step(action)  # take a random action
     if done:
         print(f"Episode finished. {ts=}")


### PR DESCRIPTION
This PR changes our AdversarialCartPoleEnvironment to use the PyBullet implementation. It adds a force on each step based on the adversarial action given in step_two_agents.

The force is applied to the cart based on the adversarial action. To sync with the original paper it should be applied to the center of the pole. Some messing with PyBullet required. See the call to applyExternalForce in step_two_agents. It should probably apply the force to link index 2 as it's the third defined in the URDF (path <env-base>\Lib\site-packages\pybullet_data), but changing the second to parameter to 2 makes it a noop.